### PR TITLE
Potential fix for code scanning alert no. 28: Potentially uninitialized local variable

### DIFF
--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -166,6 +166,7 @@ def assert_valid_json_rpc_response(response_text: str) -> dict[str, Any]:
         response = json.loads(response_text)
     except json.JSONDecodeError as e:
         pytest.fail(f"Response is not valid JSON: {e}\nResponse: {response_text}")
+        return
 
     assert "jsonrpc" in response, "Response must have jsonrpc field"
     assert response["jsonrpc"] == "2.0", "Response must be JSON-RPC 2.0"


### PR DESCRIPTION
Potential fix for [https://github.com/trsdn/markitdown-mcp/security/code-scanning/28](https://github.com/trsdn/markitdown-mcp/security/code-scanning/28)

To fix the potential use of an uninitialized local variable, we should ensure that the function does not proceed beyond the `except` block where `response` would remain undefined. The best way to fix this is by adding a `return` statement immediately after the call to `pytest.fail` in the `except` block, guaranteeing that the function exits and does not attempt to access `response`. This change should be made in file `tests/helpers/assertions.py`, specifically in the `assert_valid_json_rpc_response` function, at line 168, directly after the call to `pytest.fail`.

No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
