### PR TITLE
feat: honor MARKITDOWN_SAFE_DIRS env var for configurable safe directories

### DIFF
--- a/markitdown_mcp/server.py
+++ b/markitdown_mcp/server.py
@@ -657,6 +657,24 @@ def get_safe_working_directories() -> list[str]:
     if fixtures_dir.exists():
         safe_dirs.append(str(fixtures_dir))
 
+    # User-configured additional safe directories (os.pathsep separated).
+    # Example (Windows): MARKITDOWN_SAFE_DIRS="D:\OneDrive;D:\Projects"
+    # Example (Unix):    MARKITDOWN_SAFE_DIRS="/mnt/nas:/srv/data"
+    extra = os.environ.get("MARKITDOWN_SAFE_DIRS", "")
+    if extra:
+        for entry in extra.split(os.pathsep):
+            entry = entry.strip().strip('"')
+            if not entry:
+                continue
+            p = Path(entry)
+            if p.exists():
+                safe_dirs.append(str(p.resolve()))
+            else:
+                logger.warning(
+                    "MARKITDOWN_SAFE_DIRS entry does not exist, ignoring: %s",
+                    entry,
+                )
+
     return safe_dirs
 
 


### PR DESCRIPTION
Closes #38.

Adds support for the `MARKITDOWN_SAFE_DIRS` env variable, an `os.pathsep`-separated list of absolute paths appended to the safe-directory list. Rationale and security notes in #38.

### Behavior

- Variable unset or empty → no change.
- Separator: `:` on Unix, `;` on Windows (via `os.pathsep`).
- Non-existent entries → logged at `WARNING`, skipped.
- All entries go through `Path.resolve()` so the existing prefix-based safety check continues to handle `..` inputs correctly.

### Parallel to #37

This branch is cut from `main` (not from the #37 branch) so the PRs are reviewable independently. The only textual overlap with #37 is inside `get_safe_working_directories()`; once one of the two lands, the other rebases trivially.
