### PR TITLE
ci: reduce unnecessary workflow runs

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -266,6 +266,7 @@ jobs:
 
       - name: Check for dependency vulnerabilities
         run: |
+          python -m pip install --upgrade pip
           pip install pip-audit
           pip-audit --desc
 

--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -3,6 +3,11 @@ name: CI Quality Gates
 on:
   pull_request:
     branches-ignore: [ci-cd-maintenance]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/ci-gates.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches-ignore: [ci-cd-maintenance]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/ci.yml'
 
 # Cancel duplicate runs
 concurrency:

--- a/.github/workflows/code-annotations.yml
+++ b/.github/workflows/code-annotations.yml
@@ -3,6 +3,12 @@ name: Code Annotations & Inline Comments
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore: [ci-cd-maintenance]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/code-annotations.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,9 +3,13 @@ name: Dependency Review
 on:
   pull_request:
     branches-ignore: [ci-cd-maintenance]
-  # Also run on Dependabot PRs
-  pull_request_target:
-    branches-ignore: [ci-cd-maintenance]
+    paths:
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '**/requirements*.txt'
+      - '**/poetry.lock'
+      - '**/Pipfile.lock'
+      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/docs-autogen.yml
+++ b/.github/workflows/docs-autogen.yml
@@ -11,8 +11,6 @@ on:
           - api
           - all
           - missing
-  schedule:
-    - cron: '0 3 1 * *'  # Monthly on the 1st at 3 AM UTC
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -194,10 +194,10 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install pdoc
+      - name: Install documentation dependencies
         run: |
           pip install --upgrade pip
-          pip install pdoc
+          pip install -e ".[docs]"
 
       - name: Generate API documentation preview
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,15 @@ name: Documentation CI
 on:
   pull_request:
     branches-ignore: [ci-cd-maintenance]
+    paths:
+      - '**/*.py'
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+      - 'pyproject.toml'
+      - '.github/workflows/docs.yml'
   push:
     branches: [main]
-  schedule:
-    - cron: '0 2 * * 1'  # Weekly on Monday at 2 AM UTC for link rot detection
 
 permissions:
   contents: read

--- a/.github/workflows/fast-tests.yml
+++ b/.github/workflows/fast-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches-ignore: [ci-cd-maintenance]
     paths:
-      - '**.py'
+      - '**/*.py'
       - 'pyproject.toml'
       - 'requirements*.txt'
       - '.github/workflows/fast-tests.yml'

--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches-ignore: [ci-cd-maintenance]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/pr-feedback.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,10 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches-ignore: [ci-cd-maintenance]
-  schedule:
-    # Run security scans daily at 3 AM UTC
-    - cron: '0 3 * * *'
-
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/security.yml'
 # Cancel duplicate runs
 concurrency:
   group: security-${{ github.ref }}

--- a/.github/workflows/status-dashboard.yml
+++ b/.github/workflows/status-dashboard.yml
@@ -1,8 +1,6 @@
 name: Status Dashboard
 
 on:
-  schedule:
-    - cron: '0 */6 * * *'  # Every 6 hours
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches-ignore: [ci-cd-maintenance]
-  schedule:
-    # Run tests daily at 2 AM UTC
-    - cron: '0 2 * * *'
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
     inputs:
       test_level:
@@ -529,4 +531,3 @@ jobs:
           name: nightly-${{ matrix.test-category }}-results
           path: |
             pytest-results.xml
-

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -9,15 +9,11 @@ name: Automated Version Bump
 #
 # TRIGGERS:
 # - Automatic: Push to main (if changes warrant a version bump)
-# - Scheduled: Weekly on Mondays at 9 AM UTC
 # - Manual: workflow_dispatch (with duplicate prevention)
 
 on:
   push:
     branches: [main]
-  schedule:
-    # Run weekly on Monday at 9 AM UTC
-    - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       force_bump:


### PR DESCRIPTION
## Summary
- Add PR path filters so heavyweight workflows only run when relevant files change
- Remove duplicate dependency-review trigger
- Disable scheduled test, security, docs, dashboard, and version-bump runs for this inactive repo

## Validation
- Parsed all workflow YAML files
- Confirmed no remaining `schedule:` or `cron:` triggers
- Ran `git diff --check`