### PR TITLE
perf: remove path validation delay

### DIFF
--- a/markitdown_mcp/server.py
+++ b/markitdown_mcp/server.py
@@ -535,7 +535,6 @@ def safe_convert_with_limits(markitdown_instance: MarkItDown, file_path: str) ->
         sys.setrecursionlimit(original_limit)
 
 
-@normalize_timing
 def validate_and_sanitize_path(
     file_path: str, allowed_dirs: list[str] | None = None
 ) -> tuple[Path, bool]:

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -12,16 +12,17 @@ import pytest
 
 from markitdown_mcp.server import (
     MarkItDownMCPServer,
-    MCPRequest,
     SecurityError,
-    validate_xml_security,
-    validate_json_security,
     extract_text_from_binary,
-    sanitize_unicode_text,
-    with_timeout,
-    validate_base64,
+    normalize_timing,
     safe_convert_with_limits,
+    sanitize_unicode_text,
+    secure_compare,
+    validate_base64,
     validate_file_content_security,
+    validate_json_security,
+    validate_xml_security,
+    with_timeout,
 )
 
 
@@ -200,6 +201,35 @@ class TestAdditionalCoverage:
 
         result = operation()
         assert result == "no timeout"
+
+    def test_secure_compare(self):
+        """Test constant-time comparison helper."""
+        assert secure_compare("same", "same") is True
+        assert secure_compare("same", "different") is False
+
+    def test_normalize_timing_success(self):
+        """Test timing normalization decorator returns successful results."""
+        @normalize_timing
+        def operation():
+            return "normalized"
+
+        start_time = time.time()
+        result = operation()
+
+        assert result == "normalized"
+        assert time.time() - start_time >= 0.05
+
+    def test_normalize_timing_exception(self):
+        """Test timing normalization decorator re-raises exceptions."""
+        @normalize_timing
+        def operation():
+            raise ValueError("normalized error")
+
+        start_time = time.time()
+        with pytest.raises(ValueError, match="normalized error"):
+            operation()
+
+        assert time.time() - start_time >= 0.05
 
     def test_validate_base64_valid(self):
         """Test base64 validation with valid data."""


### PR DESCRIPTION
## Summary

Removes the timing-normalization wrapper from `validate_and_sanitize_path()`. The wrapper added a minimum ~50ms delay to every path validation even though this code path does not compare secrets or perform authentication checks.

Measured locally:
- Before: 20 validations in 1.070s (~53.5ms/call)
- After: 20 validations in 0.000826s (~0.041ms/call)

This improves `convert_file` latency and any workflow that validates many paths while preserving the existing path traversal, directory allow-list, dangerous path, and extension checks.

## 10 performance improvements identified

1. Remove artificial path-validation delay. Highest impact / lowest effort; implemented in this PR.
2. Lower validation-path logging from `info` to `debug` to reduce repeated conversion overhead and noisy stderr during batch operations.
3. Reuse a resolved safe-directory list instead of resolving allowed directories on every validation call.
4. Parallelize `convert_directory` conversions with bounded concurrency instead of processing supported files serially.
5. Avoid dispatching simple output writes through the executor in `convert_directory`; write synchronously after conversion or batch writes.
6. Add a direct fast path for plain text / markdown files to avoid MarkItDown overhead when no transformation is needed.
7. Cache the supported-formats response string instead of rebuilding it for each `list_supported_formats` call.
8. Stream or chunk output truncation for very large conversion results rather than holding full text before truncating.
9. Replace full JSON `read()` + `json.loads()` validation with a streaming/depth-limited parser to reduce memory for large JSON files.
10. Replace XML full-file regex validation with bounded pre-scan/streaming validation to reduce memory and regex cost on large XML files.

## Validation

- `ruff check markitdown_mcp/server.py`
- `pytest tests/unit/test_convert_file_tool.py tests/unit/test_convert_directory_tool.py tests/security/test_path_traversal.py --quiet` — 62 passed
- `pytest -m 'not performance and not slow and not security' --quiet` — 190 passed, 2 skipped, 90 deselected
- `pytest tests/security/test_path_traversal.py --quiet` — 18 passed

Note: full `pytest --quiet` currently fails in unrelated existing performance/security tests: two memory-threshold tests in `tests/performance/test_memory_usage.py` and two JSON bomb generation failures in `tests/security/test_malicious_files.py` on Python 3.12 before the server handles the files.
