### PR TITLE
refactor(ci): harden release follow-up jobs (force-with-lease, GH_REPO)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,8 +561,10 @@ jobs:
           git add CHANGELOG.md
           git commit -m "docs: update changelog for v${VERSION}"
 
-          # Re-runs of the same tag reuse the branch; overwrite it instead of failing.
-          git push --force origin "$BRANCH"
+          # Re-runs of the same tag reuse the branch; overwrite it instead of
+          # failing, but keep --force-with-lease so a foreign commit that landed
+          # on the branch is not silently discarded.
+          git push --force-with-lease origin "$BRANCH"
 
           if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             echo "✅ Pull request for $BRANCH already open, updated with latest changelog"
@@ -597,8 +599,7 @@ jobs:
           echo "🔍 Validating release completion for $TAG"
 
           # Check GitHub release
-          # -R is required: this job has no checkout, so gh cannot infer the repo.
-          if gh release view "$TAG" -R "${{ github.repository }}" >/dev/null 2>&1; then
+          if gh release view "$TAG" >/dev/null 2>&1; then
             echo "✅ GitHub release exists"
           else
             echo "❌ GitHub release missing"
@@ -629,6 +630,10 @@ jobs:
           echo "🎉 Release validation completed successfully!"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout, so `gh` cannot infer the repository from a
+          # git remote and reported "GitHub release missing" for a release that
+          # actually existed.
+          GH_REPO: ${{ github.repository }}
 
       - name: Notify on failure
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Release workflow: `post-release-validation` now passes `-R <repo>` to `gh release view`,
-  so the check no longer fails with "GitHub release missing" in a job without a checkout.
+- Release workflow: `post-release-validation` now sets `GH_REPO` for the step, so `gh`
+  resolves the repository in a job without a checkout instead of failing the check with
+  "GitHub release missing".
 - Release workflow: the PyPI verification uses the PyPI JSON API with retries instead of
   the experimental `pip index versions` plus a substring `grep`.
 - Release workflow: `update-docs` opens a pull request with the changelog update instead of


### PR DESCRIPTION
Follow-up to #50 (merged as `a998c5a`), applying two review refinements from the
comparison with the parallel PR #49.

## 1. `--force` → `--force-with-lease`

`update-docs` overwrites `docs/changelog-v<version>` on a re-run of the same tag.
`--force-with-lease` keeps that idempotency but refuses to discard a foreign
commit that landed on the branch in the meantime. The lease basis is sound here:
the job checks out with `fetch-depth: 0`, so remote-tracking refs for all
branches exist before the push.

## 2. `-R` on the call → `GH_REPO` in the step env

`post-release-validation` has no `actions/checkout`, so `gh` cannot infer the
repository from a git remote — that was the root cause of the false
"❌ GitHub release missing". Setting it via the step env instead of a single
`-R` flag covers every `gh` call in the step and puts the explanatory comment
where the cause actually is:

```yaml
env:
  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  # This job has no checkout, so `gh` cannot infer the repository from a
  # git remote and reported "GitHub release missing" for a release that
  # actually existed.
  GH_REPO: ${{ github.repository }}
```

## Deliberately *not* included: tag guards

PR #49 additionally adds `if: startsWith(github.ref, 'refs/tags/')` to `publish`,
`create-github-release` and `post-release-validation`. That is not adopted here,
on purpose.

This workflow has a **required `tag` input on `workflow_dispatch`**, and every job
checks out `ref: ${{ inputs.tag || github.ref }}` — a dispatch is the intended way
to re-run the pipeline for an existing tag. During a `workflow_dispatch` run,
`github.ref` is `refs/heads/main`, so the condition would always evaluate to
`false` and those three jobs would be **silently skipped**. That is precisely the
re-run path that v2.0.0 depended on (three attempts, because of the mypy/3.12
gate).

## Validation

- `actionlint .github/workflows/release.yml` — no findings in the changed jobs
  (remaining SC2086/SC2046 infos are pre-existing, in untouched jobs)
- YAML parses cleanly
- `grep startsWith(github.ref` confirms no tag guards were introduced
- CHANGELOG `[Unreleased] / ### Fixed` wording updated to match the `GH_REPO` approach

Only `update-docs` and `post-release-validation` are touched. No release run, no
tag created, release workflow not triggered.
