### PR TITLE
fix(release): never attempt a PyPI upload from workflow_dispatch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,10 +22,10 @@ on:
         default: false
         type: boolean
 
+# Least privilege by default; jobs opt into what they need.
+# `id-token: write` is granted ONLY to the TestPyPI upload job.
 permissions:
-  contents: write
-  id-token: write
-  packages: write
+  contents: read
 
 # Ensure only one pre-release runs at a time
 concurrency:
@@ -323,6 +323,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare-prerelease, build-prerelease]
     environment: test-pypi
+    # No API tokens: authentication happens via short-lived OIDC credentials.
+    permissions:
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -362,6 +365,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare-prerelease, build-prerelease, test-pypi-upload]
     if: always() && needs.prepare-prerelease.result == 'success' && needs.build-prerelease.result == 'success'
+    # Pushes the pre-release tag and creates the GitHub pre-release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,7 +426,12 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [validate-release, quality-gates, security-scan, build-package, generate-changelog]
-    if: needs.validate-release.outputs.is-prerelease == 'false'
+    # Only ever upload from a tag push. A manual `workflow_dispatch` run is a
+    # dry run of build + quality gates: PyPI rejects re-uploading an existing
+    # version, so a dispatch that reached this job would always fail.
+    if: |
+      startsWith(github.ref, 'refs/tags/')
+      && needs.validate-release.outputs.is-prerelease == 'false'
     environment: pypi
     # No API tokens: authentication happens via short-lived OIDC credentials.
     permissions:
@@ -466,8 +471,11 @@ jobs:
     needs: [validate-release, build-package, generate-changelog, publish]
     # `always()` so prereleases (where `publish` is skipped) still get a GitHub
     # release, but never when a required upstream job actually failed.
+    # Tag-only for the same reason as `publish`: a manual dispatch must not try
+    # to create a release for a ref that is not a tag.
     if: |
       always()
+      && startsWith(github.ref, 'refs/tags/')
       && needs.validate-release.result == 'success'
       && needs.build-package.result == 'success'
       && needs.generate-changelog.result == 'success'
@@ -587,7 +595,9 @@ jobs:
     name: Post-Release Validation
     runs-on: ubuntu-latest
     needs: [validate-release, create-github-release, publish, update-docs]
-    if: always()
+    # Tag-only: on a manual dispatch there is no release to validate, so this
+    # would always fail with "GitHub release missing".
+    if: always() && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Validate release completion
         run: |


### PR DESCRIPTION
Follow-up to #48 / #50. Last remaining hardening: **`release.yml` accepts `workflow_dispatch`, but nothing stopped a manual run from attempting a PyPI upload.**

`publish` was gated only on `is-prerelease`, so a manual dispatch ran all the way to the upload and would always fail — PyPI rejects re-uploading an existing version.

## Fix

`startsWith(github.ref, 'refs/tags/')` added to three jobs:

| Job | Condition |
|---|---|
| `publish` | `startsWith(github.ref, 'refs/tags/') && needs.validate-release.outputs.is-prerelease == 'false'` |
| `create-github-release` | `always() && startsWith(github.ref, 'refs/tags/') && …` |
| `post-release-validation` | `always() && startsWith(github.ref, 'refs/tags/')` |

`post-release-validation` needed it too: with a bare `if: always()` every dispatch would end in "GitHub release missing". A manual dispatch is now a clean dry run of build + quality gates.

This matches the guard already in place in `trsdn/paperless-mcp` and `trsdn/obsidian-mcp`.

## `pre-release.yml`: tag guard deliberately NOT applied

That workflow is triggered **only** by `workflow_dispatch` and generates the rc/alpha/beta version itself, so a tag guard would disable it entirely. The TestPyPI duplicate risk there only materialises if the same version is generated twice — a separate question that should be decided on its own.

What was fixed there instead is the same least-privilege gap already closed in `release.yml` — `id-token: write` sat at workflow level:

```yaml
# before (workflow level)      # after
permissions:                   permissions:
  contents: write                contents: read
  id-token: write              # test-pypi-upload:  { id-token: write }
  packages: write              # create-prerelease: { contents: write }
```

`packages: write` was unused and is removed.

## Validation

- `actionlint` on both workflows: **12 findings, identical to `main`** (all pre-existing, in untouched lines).
- All three `if` expressions and the rescoped permissions verified by parsing the YAML.

Note: this branch originally also carried the `update-docs` / `post-release-validation` / `pip index versions` fixes. Those landed via #50, so the branch was rebuilt on top of `main` and now contains only the change above.
