### PR TITLE
fix(ci): drop paths filter from required-check workflows (branch-protection deadlock)

### DIFF
--- a/.github/workflows/ci-gates.yml
+++ b/.github/workflows/ci-gates.yml
@@ -1,13 +1,13 @@
 name: CI Quality Gates
 
 on:
+  # NOTE: Deliberately no `paths:` filter here. This workflow provides the
+  # required status check "Unit Tests & Coverage" on `main`. A path filter would
+  # prevent the workflow from running on PRs that touch no matching files
+  # (e.g. docs-only or YAML-only PRs), so the required check would never report
+  # and the PR would stay blocked forever waiting on a status that never arrives.
   pull_request:
     branches-ignore: [ci-cd-maintenance]
-    paths:
-      - '**/*.py'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - '.github/workflows/ci-gates.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/fast-tests.yml
+++ b/.github/workflows/fast-tests.yml
@@ -1,13 +1,14 @@
 name: Fast Tests
 
 on:
+  # NOTE: Deliberately no `paths:` filter here. This workflow provides the
+  # required status checks "Integration Smoke Tests" and "Quick Security Scan"
+  # on `main`. A path filter would prevent the workflow from running on PRs that
+  # touch no matching files (e.g. docs-only or YAML-only PRs), so those required
+  # checks would never report and the PR would stay blocked forever waiting on
+  # statuses that never arrive.
   pull_request:
     branches-ignore: [ci-cd-maintenance]
-    paths:
-      - '**/*.py'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - '.github/workflows/fast-tests.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- CI: removed the `paths:` filter from the `pull_request` trigger of `ci-gates.yml` and
+  `fast-tests.yml`. These workflows provide the required status checks `Unit Tests &
+  Coverage`, `Integration Smoke Tests` and `Quick Security Scan`; with a path filter they
+  never ran on PRs without matching files (docs- or YAML-only, e.g. the automated
+  `docs/changelog-v*` release PRs), so those checks never reported and the PRs stayed
+  blocked indefinitely.
 - Release workflow: `post-release-validation` now sets `GH_REPO` for the step, so `gh`
   resolves the repository in a job without a checkout instead of failing the check with
   "GitHub release missing".


### PR DESCRIPTION
## The problem

Branch protection on `main` requires four status checks:

```
All Checks Status
Quick Security Scan
Integration Smoke Tests
Unit Tests & Coverage
```

(`strict: true`, `required_approving_review_count: 0`, `enforce_admins: false`)

Three of the four come from **path-filtered** workflows:

| Required context | Workflow |
| --- | --- |
| `Unit Tests & Coverage` | `.github/workflows/ci-gates.yml` |
| `Integration Smoke Tests` | `.github/workflows/fast-tests.yml` |
| `Quick Security Scan` | `.github/workflows/fast-tests.yml` |

Both had a `paths:` filter on the `pull_request` trigger (`**/*.py`, `pyproject.toml`, `requirements*.txt`, own workflow file).

This is the classic **path-filtered required checks** anti-pattern: on a PR that touches none of those paths — e.g. a Markdown- or YAML-only change — the workflows never trigger, therefore never report a status, and the PR stays `BLOCKED` forever. No timeout, no error; it just hangs waiting for checks that will never arrive.

`All Checks Status` (`pr-summary.yml`) is *not* path-filtered and reports correctly. Only the three above are affected.

## Why this is urgent

`.github/workflows/release.yml` job `update-docs` automatically opens a PR on branch `docs/changelog-v<VERSION>` that changes **only `CHANGELOG.md`**. That is exactly the failing pattern — the release automation produces PRs that can never be merged without an admin override.

This already happened for real: PRs #50 and #51 (YAML + Markdown only) had to be merged with `gh pr merge --admin` because the checks never reported.

## The fix

Remove the `paths:` filter from the `pull_request` trigger in both workflows, with an explanatory comment above each trigger. `push:` and `workflow_dispatch:` are unchanged. **No changes** to jobs, job `name:` fields (these are the required context names), `concurrency` or `permissions`. Branch protection is untouched — the fix belongs in the workflows, not in the protection rule.

## Trade-off (deliberate)

Docs-only PRs now also run the Python tests, costing a bit of CI time. That is acceptable: these are the workflows explicitly designed as "fast" (`fast-tests.yml` has `timeout-minutes: 10`), and a permanently blocked PR is far more expensive than a few minutes of runner time.

The alternative — a second workflow with identical job names running on the complementary paths and reporting success only — is error-prone: the job names would have to be kept in sync in two places, and any drift reintroduces exactly this deadlock.

## Note on this PR's own checks

This PR changes only YAML and Markdown, i.e. the affected category in general. It does *not* get stuck itself, because it modifies `.github/workflows/ci-gates.yml` and `.github/workflows/fast-tests.yml`, and those paths were part of the old filters — so the workflows still trigger here and all four required checks report normally. (Confirmed on this PR: `Unit Tests & Coverage`, `Integration Smoke Tests`, `Quick Security Scan` and `All Checks Status` all ran.)

Any other docs-only PR — in particular the automated `docs/changelog-v*` PR from `release.yml` — *would* hang. That is what this change fixes, from the merge onward.

## Validation

- `actionlint` on both files: 6 shellcheck findings, identical to the baseline before the change (pre-existing SC2086 in untouched `run:` blocks) — no new findings.
- YAML parse check with Python confirms the resulting `on:` blocks.
- Verified all four required contexts still match existing job `name:` values exactly.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
