### PR TITLE
fix(ci): restore the workflow_dispatch re-run path in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,12 +426,13 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [validate-release, quality-gates, security-scan, build-package, generate-changelog]
-    # Only ever upload from a tag push. A manual `workflow_dispatch` run is a
-    # dry run of build + quality gates: PyPI rejects re-uploading an existing
-    # version, so a dispatch that reached this job would always fail.
-    if: |
-      startsWith(github.ref, 'refs/tags/')
-      && needs.validate-release.outputs.is-prerelease == 'false'
+    # `workflow_dispatch` takes a required `tag` input and every job checks that
+    # tag out, so a dispatch is a re-run of the pipeline for an existing tag --
+    # not a dry run. Guarding on `github.ref` would therefore always be false on
+    # a dispatch (it is `refs/heads/main`) and silently skip the upload.
+    # A duplicate upload is already prevented by the "Check if tag already
+    # exists in releases" step in `validate-release`.
+    if: needs.validate-release.outputs.is-prerelease == 'false'
     environment: pypi
     # No API tokens: authentication happens via short-lived OIDC credentials.
     permissions:
@@ -471,11 +472,8 @@ jobs:
     needs: [validate-release, build-package, generate-changelog, publish]
     # `always()` so prereleases (where `publish` is skipped) still get a GitHub
     # release, but never when a required upstream job actually failed.
-    # Tag-only for the same reason as `publish`: a manual dispatch must not try
-    # to create a release for a ref that is not a tag.
     if: |
       always()
-      && startsWith(github.ref, 'refs/tags/')
       && needs.validate-release.result == 'success'
       && needs.build-package.result == 'success'
       && needs.generate-changelog.result == 'success'
@@ -597,9 +595,9 @@ jobs:
     name: Post-Release Validation
     runs-on: ubuntu-latest
     needs: [validate-release, create-github-release, publish, update-docs]
-    # Tag-only: on a manual dispatch there is no release to validate, so this
-    # would always fail with "GitHub release missing".
-    if: always() && startsWith(github.ref, 'refs/tags/')
+    # Runs for dispatch re-runs too: `validate-release` resolves the tag from the
+    # required `tag` input, so there is always a release to validate.
+    if: always()
     steps:
       - name: Validate release completion
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Release workflow: `publish`, `create-github-release` and `post-release-validation` no
+  longer require `github.ref` to be a tag. `workflow_dispatch` takes a required `tag`
+  input and every job checks that tag out, so a dispatch is a re-run of the pipeline for
+  an existing tag; on a dispatch `github.ref` is `refs/heads/main`, so the guard was
+  always false and silently skipped the upload while the run still reported success.
+  Duplicate uploads remain prevented by the existing "Check if tag already exists in
+  releases" step in `validate-release`.
 - CI: removed the `paths:` filter from the `pull_request` trigger of `ci-gates.yml` and
   `fast-tests.yml`. These workflows provide the required status checks `Unit Tests &
   Coverage`, `Integration Smoke Tests` and `Quick Security Scan`; with a path filter they


### PR DESCRIPTION
Follow-up to #52. That PR's least-privilege permissions work in `pre-release.yml` is good and stays untouched — this only reverts the three tag guards it added to `release.yml`.

## The problem

#52 added to `publish`, `create-github-release` and `post-release-validation`:

```yaml
if: startsWith(github.ref, 'refs/tags/')
```

with the rationale that "a manual `workflow_dispatch` run is a dry run of build + quality gates". That is not what a dispatch means in this workflow:

```yaml
workflow_dispatch:
  inputs:
    tag:
      description: 'Existing release tag to (re-)run the pipeline for, e.g. v1.2.3'
      required: true
      type: string
```

The input is **required**, and every job checks it out via `ref: ${{ inputs.tag || github.ref }}` (lines 39, 91, 148, 191, 290, 488). A dispatch is the documented way to re-run the pipeline for a tag that already exists.

On `workflow_dispatch`, `github.ref` is `refs/heads/main`, never `refs/tags/*`. So the guard was **always false**: `publish` was skipped, `create-github-release` was skipped, and the run still finished green. Failure that looks like success — the worst kind.

## Why this matters concretely

`v2.0.0` needed three attempts (`21:56`, `22:08`, `22:12`) because the `mypy --strict` gate failed on Python 3.12 over a PEP 695 `type` statement in the numpy stubs. A tag that exists with a half-finished pipeline is exactly the situation the dispatch re-run exists for. With the guard in place the only remaining option would be deleting and re-pushing the tag.

## The risk it was meant to address is already covered

A duplicate upload cannot slip through, because `validate-release` runs:

```yaml
- name: Check if tag already exists in releases
  run: |
    if gh release view "$TAG" >/dev/null 2>&1; then
      echo "❌ Release for tag $TAG already exists"
      exit 1
    fi
```

A re-run of a fully completed release fails early and loudly. A re-run of a half-failed one proceeds, which is the intent.

## Changes

- Dropped the guard from all three jobs, replacing each comment with the reason it must *not* be there, so this does not get re-added a third time
- `CHANGELOG.md` entry under `[Unreleased]`

## Validation

- `actionlint`: 7 shellcheck findings before, 7 after — all pre-existing in untouched jobs, none introduced
- Job conditions re-parsed from YAML:
  ```
  publish                 | needs.validate-release.outputs.is-prerelease == 'false'
  create-github-release   | always() && needs.validate-release.result == 'success' && ...
  post-release-validation | always()
  ```
- `grep -c "startsWith(github.ref" .github/workflows/release.yml` → 0

## Note on the same guard elsewhere

In trsdn/obsidian-mcp I deliberately *added* this exact guard (PR #11). There `workflow_dispatch` has **no** tag input, so a dispatch would have published whatever version `main` held. Same line, opposite effect — what decides it is the trigger design of the individual workflow.
