### PR TITLE
chore: sync version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trsdn-markitdown-mcp"
-version = "1.2.2"
+version = "2.0.0"
 description = "An independent Model Context Protocol (MCP) server for converting documents to Markdown using MarkItDown"
 authors = [
     { name = "trsdn", email = "noreply@users.noreply.github.com" },


### PR DESCRIPTION
pyproject.toml stand auf 1.2.2, waehrend auf PyPI und als Git-Tag bereits 2.0.0 veroeffentlicht ist. Der Bump beim 2.0.0-Release wurde nie auf main nachgezogen.

Folge: Der version-bump-Workflow rechnete von der falschen Basis und schlug 1.2.3 vor (PR #55, geschlossen) - eine Rueckwaertsversion unterhalb der publizierten 2.0.0. Ein Release daraus waere fehlgeschlagen oder haette eine aeltere Version als latest gesetzt.

Setzt die Version auf den tatsaechlich veroeffentlichten Stand 2.0.0. Kein Release, kein Tag - reine Synchronisierung.